### PR TITLE
Add Ethereum network support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Polygon MCP Server
 
-A Model Context Protocol (MCP) server that provides onchain tools for Claude AI, allowing it to interact with the Polygon PoS blockchain.
+A Model Context Protocol (MCP) server that provides onchain tools for Claude AI, allowing it to interact with blockchain networks such as Polygon PoS and Ethereum mainnet. Polygon is used by default.
 
 ## Features
 
-- Call contract functions on Polygon PoS
+- Call contract functions on supported chains
 - Get ERC20 token balances
 - Transfer ERC20 tokens
 - Get current gas prices
@@ -33,6 +33,7 @@ Create a `.env` file in the root directory with the following variables:
 
 ```
 SEED_PHRASE="your twelve word seed phrase here"
+# Optional: set CHAIN="ethereum" to use Ethereum mainnet
 ```
 
 ## Usage
@@ -85,7 +86,7 @@ For Claude desktop app:
 
 ### call_contract
 
-Call a contract function on Polygon PoS.
+Call a contract function on the configured chain (Polygon by default).
 
 Parameters:
 - `contractAddress`: The address of the contract to call
@@ -96,14 +97,14 @@ Parameters:
 
 ### erc20_balance
 
-Get the balance of an ERC20 token on Polygon PoS.
+Get the balance of an ERC20 token on the configured chain.
 
 Parameters:
 - `contractAddress`: The address of the contract to get the balance of
 
 ### erc20_transfer
 
-Transfer an ERC20 token on Polygon PoS.
+Transfer an ERC20 token on the configured chain.
 
 Parameters:
 - `contractAddress`: The address of the contract to transfer the token from
@@ -112,7 +113,7 @@ Parameters:
 
 ### get_gas_price
 
-Get the current gas price on Polygon PoS.
+Get the current gas price on the configured chain.
 
 ## License
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,10 +7,15 @@ import {
 import { version } from "./version.js";
 import * as dotenv from "dotenv";
 import { mnemonicToAccount } from "viem/accounts";
-import { polygon } from "viem/chains";
+import { polygon, mainnet } from "viem/chains";
 import { createWalletClient, http, publicActions } from "viem";
 import { polygonMcpTools, toolToHandler } from "./tools/index.js";
-import { POLYGON_RPC_URL } from "./lib/constants.js";
+import {
+  POLYGON_RPC_URL,
+  POLYGON_CHAIN_ID,
+  ETHEREUM_RPC_URL,
+  ETHEREUM_CHAIN_ID,
+} from "./lib/constants.js";
 
 // 扩展viemClient类型，添加oneInchApiKey属性
 type ExtendedViemClient = ReturnType<typeof createWalletClient> & 
@@ -21,6 +26,20 @@ async function main() {
   dotenv.config();
   const seedPhrase = process.env.SEED_PHRASE;
   const oneInchApiKey = process.env.ONE_INCH_API_KEY;
+  const chainName = process.env.CHAIN || "polygon";
+
+  let chain;
+  let rpcUrl;
+
+  if (chainName === "ethereum") {
+    chain = mainnet;
+    rpcUrl = ETHEREUM_RPC_URL;
+  } else {
+    chain = polygon;
+    rpcUrl = POLYGON_RPC_URL;
+  }
+
+  console.log("Using chain:", chainName);
 
   // 打印环境变量，用于调试
   console.log("Environment variables:");
@@ -42,8 +61,8 @@ async function main() {
 
   const viemClient = createWalletClient({
     account: mnemonicToAccount(seedPhrase),
-    chain: polygon,
-    transport: http(POLYGON_RPC_URL),
+    chain,
+    transport: http(rpcUrl),
   }).extend(publicActions) as ExtendedViemClient;
 
   // 将环境变量添加到viemClient对象中，以便在处理程序中访问
@@ -51,7 +70,7 @@ async function main() {
 
   const server = new Server(
     {
-      name: "Polygon MCP Server",
+      name: `${chainName === "ethereum" ? "Ethereum" : "Polygon"} MCP Server`,
       version,
     },
     {
@@ -101,7 +120,7 @@ async function main() {
   const transport = new StdioServerTransport();
   console.error("Connecting server to transport...");
   await server.connect(transport);
-  console.error("Polygon MCP Server running on stdio");
+  console.error(`${chainName === "ethereum" ? "Ethereum" : "Polygon"} MCP Server running on stdio`);
 }
 
 main().catch((error) => {

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -5,3 +5,7 @@ export const USDC_DECIMALS = 6;
 // Polygon PoS network details
 export const POLYGON_RPC_URL = "https://polygon-rpc.com/";
 export const POLYGON_CHAIN_ID = 137;
+
+// Ethereum mainnet details
+export const ETHEREUM_RPC_URL = "https://eth.llamarpc.com";
+export const ETHEREUM_CHAIN_ID = 1;

--- a/src/tools/handlers.ts
+++ b/src/tools/handlers.ts
@@ -22,7 +22,7 @@ import type {
   checkAllowanceSchema,
   approveTokenSchema
 } from "./schemas.js";
-import { constructPolygonScanUrl } from "../utils/index.js";
+import { constructExplorerUrl } from "../utils/index.js";
 import { polygon } from "viem/chains";
 import { PropertyNFT } from "../contracts/PropertyNFT.js";
 import { PropertyToken } from "../contracts/PropertyToken.js";
@@ -46,7 +46,7 @@ export async function deployPropertyNFTHandler(
   // Return transaction hash and PolygonScan URL
   return JSON.stringify({
     hash,
-    url: constructPolygonScanUrl(wallet.chain ?? polygon, hash),
+    url: constructExplorerUrl(wallet.chain ?? polygon, hash),
   });
 }
 
@@ -79,7 +79,7 @@ export async function deployPropertyTokenHandler(
   // Return transaction hash and PolygonScan URL
   return JSON.stringify({
     hash,
-    url: constructPolygonScanUrl(wallet.chain ?? polygon, hash),
+    url: constructExplorerUrl(wallet.chain ?? polygon, hash),
   });
 }
 
@@ -116,7 +116,7 @@ export async function deployPropertyYieldVaultHandler(
   // Return transaction hash and PolygonScan URL
   return JSON.stringify({
     hash,
-    url: constructPolygonScanUrl(wallet.chain ?? polygon, hash),
+    url: constructExplorerUrl(wallet.chain ?? polygon, hash),
   });
 }
 
@@ -180,7 +180,7 @@ export async function callContractHandler(
 
   return JSON.stringify({
     hash: txHash,
-    url: constructPolygonScanUrl(wallet.chain ?? polygon, txHash),
+    url: constructExplorerUrl(wallet.chain ?? polygon, txHash),
   });
 }
 
@@ -247,7 +247,7 @@ export async function erc20TransferHandler(
 
   return JSON.stringify({
     hash: txHash,
-    url: constructPolygonScanUrl(wallet.chain ?? polygon, txHash),
+    url: constructExplorerUrl(wallet.chain ?? polygon, txHash),
   });
 }
 
@@ -444,7 +444,7 @@ export async function inchSwapHandler(
       // Return transaction details and estimated result
       return JSON.stringify({
         hash,
-        url: constructPolygonScanUrl(wallet.chain ?? polygon, hash),
+        url: constructExplorerUrl(wallet.chain ?? polygon, hash),
         fromToken: swapData.fromToken,
         toToken: swapData.toToken,
         fromAmount: swapData.fromAmount,
@@ -548,7 +548,7 @@ export async function approveTokenHandler(
 
     return JSON.stringify({
       hash,
-      url: constructPolygonScanUrl(wallet.chain ?? polygon, hash),
+      url: constructExplorerUrl(wallet.chain ?? polygon, hash),
       tokenAddress,
       spenderAddress,
       amount: approvalAmount.toString(),

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,7 +1,6 @@
 import type { Chain } from "viem";
-import { polygon, polygonMumbai } from "viem/chains";
-
-export function constructPolygonScanUrl(
+import { polygon, polygonMumbai, mainnet } from "viem/chains";
+export function constructExplorerUrl(
   chain: Chain,
   transactionHash: `0x${string}`,
 ) {
@@ -11,6 +10,10 @@ export function constructPolygonScanUrl(
 
   if (chain.id === polygonMumbai.id) {
     return `https://mumbai.polygonscan.com/tx/${transactionHash}`;
+  }
+
+  if (chain.id === mainnet.id) {
+    return `https://etherscan.io/tx/${transactionHash}`;
   }
 
   // Default to mainnet


### PR DESCRIPTION
## Summary
- add Ethereum chain constants and network selection
- generalize explorer URL helper
- support CHAIN env var in server
- update README to explain optional Ethereum usage

## Testing
- `npm run build`
- `npm test` *(fails: Cannot find module '/workspace/polygon-mcp/scripts/test-mcp.js')*

------
https://chatgpt.com/codex/tasks/task_e_684162eff2448325a4943b99f1417da6